### PR TITLE
Move bot id to config and make DM nicer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM elixir:1.6
 MAINTAINER hex337
 
 ARG SLACK_TOKEN
+ARG KOIN_BOT_ID
 
 ENV HOME=/usr/src/alex-koin
 
@@ -13,8 +14,7 @@ RUN apt-get update && apt-get install --yes \
     inotify-tools
 
 RUN mix local.hex --force \
-    && mix local.rebar --force \
-    && mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phx_new-1.3.3.ez
+    && mix local.rebar --force
 
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This assumes you have docker set up.
 You will also need a slack bot token to test with. You can create your own slack org for free and then add a bot integration. You'll want to set up a `.env` file with your token that looks like this:
 
 ```
-export SLACK_TOKEN=asdf-TOKEN-STUFF
+SLACK_TOKEN=asdf-TOKEN-STUFF
+KOIN_BOT_ID=UC123456
 ```
 
-You'll then need to `source .env` to get the `SLACK_TOKEN` into your env, since the process expects it for the bot to work.
-
+Docker will pick up variables defined in your `.env` when you build a container and make them available when running.
 
 ```sh
 make build

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,8 @@ use Mix.Config
 
 # General application configuration
 config :alex_koin,
-  ecto_repos: [AlexKoin.Repo]
+  ecto_repos: [AlexKoin.Repo],
+  koin_bot_id: System.get_env("KOIN_BOT_ID")
 
 # Configures the endpoint
 config :alex_koin, AlexKoinWeb.Endpoint,
@@ -25,6 +26,9 @@ config :logger, :console,
 # Configure Slack Bot
 config :alex_koin, AlexKoin.Slack,
   token: System.get_env("SLACK_TOKEN")
+
+config :slack, 
+  api_token: System.get_env("SLACK_TOKEN")
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         - SLACK_TOKEN=${SLACK_TOKEN}
+        - KOIN_BOT_ID=${KOIN_BOT_ID}
     command: "mix run --no-halt"
     ports:
       - "4000:4000"
@@ -16,6 +17,7 @@ services:
       - db
     environment:
       SLACK_TOKEN: "${SLACK_TOKEN}"
+      KOIN_BOT_ID: "${KOIN_BOT_ID}"
 
   db:
     image: "postgres:9.6.3"

--- a/lib/alex_koin/slack.ex
+++ b/lib/alex_koin/slack.ex
@@ -12,7 +12,7 @@ defmodule AlexKoin.SlackRtm do
     {:ok, state}
   end
 
-  def handle_event(%{user: @koin_bot_id}) do: {:ok, state}
+  def handle_event(%{user: @koin_bot_id}), do: {:ok, state}
   def handle_event(message = %{type: "message", channel: "D" <> _rest, user: user}, slack, state) do
     handle_msg(user, message, message_type(message.text), slack, state)
   end

--- a/lib/alex_koin/slack.ex
+++ b/lib/alex_koin/slack.ex
@@ -3,6 +3,8 @@ defmodule AlexKoin.SlackRtm do
     :alex_koin, :slack_module, Slack.Sends
   )
 
+  @koin_bot_id Application.get_env(:alex_koin, :koin_bot_id)
+
   alias AlexKoin.SlackCommands
 
   def handle_connect(slack, state) do
@@ -10,12 +12,20 @@ defmodule AlexKoin.SlackRtm do
     {:ok, state}
   end
 
-  def handle_event(message = %{type: "message", text: "<@UC37P4L3Y> " <> text, user: user}, slack, state) do
-    SlackCommands.get_or_create(user)
-    |> create_reply(message, message_type(text)) # returns tuple {text, message_ts}
-    |> send_raw_message(message.channel, slack)
+  def handle_event(message = %{type: "message", channel: "D" <> _rest, user: user}, slack, state) do
+    # Ignore if it's a message in a DM from the bot itself
+    if user == @koin_bot_id do
+      {:ok, state}
+    else
+      # We care because we don't have to thread in a DM.
+      handle_msg(user, message, message_type(message.text), slack, state)
+    end
+  end
 
-    {:ok, state}
+  def handle_event(message = %{type: "message", text: "<@" <> @koin_bot_id <> "> " <> text, user: user}, slack, state) do
+    IO.puts inspect(message)
+
+    handle_msg(user, message, message_type(text), slack, state)
   end
 
   def handle_event(_, _, state), do: {:ok, state}
@@ -30,6 +40,14 @@ defmodule AlexKoin.SlackRtm do
 
   def handle_info(_, _, state), do: {:ok, state}
 
+  defp handle_msg(user, message, message_type, slack, state) do
+    SlackCommands.get_or_create(user)
+    |> create_reply(message, message_type) # returns tuple {text, message_ts}
+    |> send_raw_message(message.channel, slack)
+
+    {:ok, state}
+  end
+
   defp message_type(text) do
     cond do
       text =~ "my balance" -> {:balance, text}
@@ -37,6 +55,7 @@ defmodule AlexKoin.SlackRtm do
       text =~ "transfer" -> {:transfer, text}
       text =~ "list koins" -> {:list_koins, text}
       text =~ "leaderboard" -> {:leaderboard, text}
+      true -> {:nothing, text}
     end
   end
 
@@ -51,7 +70,7 @@ defmodule AlexKoin.SlackRtm do
     {"Created a new coin: `#{coin.hash}` with origin: '#{coin.origin}'", nil}
   end
   defp create_reply(user, _message, {:transfer, text}) do
-    regex = ~r/ transfer (?<coin_uuid>[0-9a-zA-Z-]+) to <@(?<to_slack_id>[A-Z0-9]+)> (?<memo>.*)/
+    regex = ~r/transfer (?<coin_uuid>[0-9a-zA-Z-]+) to <@(?<to_slack_id>[A-Z0-9]+)> (?<memo>.*)/
     captures = Regex.named_captures(regex, text)
     IO.puts inspect(captures)
 
@@ -60,20 +79,34 @@ defmodule AlexKoin.SlackRtm do
 
     # validate this coin belongs to the user currently
     if coin.wallet_id == user_wallet(user).id do
-      SlackCommands.transfer_coin(coin, user_wallet(user), user_wallet(to_user), captures["memo"])
+      memo = captures["memo"]
+      SlackCommands.transfer_coin(coin, user_wallet(user), user_wallet(to_user), memo)
+
+      # Notify the recipient of the new koin
+      #notify_msg = "<@#{user.slack_id}> just transfered 1.0 :akc: with the memo: '#{memo}'"
+      #dm_channel = Slack.Web.Im.open(%{user: to_user.slack_id})
+      #  |> Map.get("channel")
+      #  |> Map.get("id")
+
+      #send_raw_message({notify_msg, nil}, dm_channel, slack)
+
       {"Transfered coin.", nil}
     else
       {"You don't own that coin.", nil}
     end
   end
   defp create_reply(user, _, {:list_koins, _text}), do: SlackCommands.get_coins(user_wallet(user))
-  defp create_reply(user,_,_), do: IO.inspect(user); {nil, nil}
+  defp create_reply(user,_,_), do: nil
 
   defp user_wallet(_user = %{id: user_id}) do
     AlexKoin.Repo.get_by(AlexKoin.Account.Wallet, user_id: user_id)
   end
+  defp message_ts(%{channel: "D" <> _rest}), do: nil
   defp message_ts(%{thread_ts: message_ts}), do: message_ts
   defp message_ts(%{ts: message_ts}), do: message_ts
+
+  defp send_raw_message(nil, _channel, _slack) do
+  end
 
   defp send_raw_message({text, message_ts}, channel, slack) do
     %{
@@ -85,6 +118,7 @@ defmodule AlexKoin.SlackRtm do
     |> Poison.encode!()
     |> @slack_module.send_raw(slack)
   end
+
   defp reason(text) do
     %{"reason" => reason} = Regex.named_captures(~r/create koin\s+(?<reason>.*)/, text)
     reason

--- a/lib/alex_koin/slack.ex
+++ b/lib/alex_koin/slack.ex
@@ -12,7 +12,7 @@ defmodule AlexKoin.SlackRtm do
     {:ok, state}
   end
 
-  def handle_event(%{user: @koin_bot_id}), do: {:ok, state}
+  def handle_event(%{type: "message", user: @koin_bot_id}, _slack, state), do: {:ok, state}
   def handle_event(message = %{type: "message", channel: "D" <> _rest, user: user}, slack, state) do
     handle_msg(user, message, message_type(message.text), slack, state)
   end


### PR DESCRIPTION
- No longer have to pre-pend the bot's name when you are dming the bot
- Configure the bot id in the env so you can test in other slacks
- Update readme
- Handle messages that don't match commands