### PR TITLE
Don't decrement old wallet if it's the same as the new_wallet

### DIFF
--- a/lib/alex_koin/slack_commands.ex
+++ b/lib/alex_koin/slack_commands.ex
@@ -158,8 +158,12 @@ defmodule AlexKoin.SlackCommands do
         Wallet.changeset(to_wallet, %{balance: to_wallet.balance + 1})
       end
     )
-    |> Multi.update(:update_from_wallet, fn %{^from_wallet_key => from_wallet} ->
-      Wallet.changeset(from_wallet, %{balance: from_wallet.balance - 1})
+    |> Multi.update(:update_from_wallet, fn
+      %{^from_wallet_key => same_wallet, ^to_wallet_key => same_wallet} ->
+        Wallet.changeset(same_wallet, %{})
+
+      %{^from_wallet_key => from_wallet} ->
+        Wallet.changeset(from_wallet, %{balance: from_wallet.balance - 1})
     end)
     |> Multi.update(:update_coin, fn %{^coin_key => coin, ^to_wallet_key => to_wallet} ->
       Coin.changeset(coin, %{wallet_id: to_wallet.id})


### PR DESCRIPTION
Fix a bug the would cause a coin creation to debit the creating wallet instead of crediting it.